### PR TITLE
Don't die! Throw an exception

### DIFF
--- a/src/MattgXyz/Twig/HexColorChangeExtension.php
+++ b/src/MattgXyz/Twig/HexColorChangeExtension.php
@@ -18,7 +18,7 @@ class HexColorChangeExtension extends Twig_Extension
     public function darken($hexcode)
     {
         if (!preg_match('/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i', $hexcode, $parts)) {
-            die("Not a value color");
+            throw new Exception("Not a value color");
         }
         $out = ""; // Prepare to fill with the results
         for ($i = 1; $i <= 3; $i++) {
@@ -36,7 +36,7 @@ class HexColorChangeExtension extends Twig_Extension
     public function lighten($hexcode)
     {
         if (!preg_match('/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i', $hexcode, $parts)) {
-            die("Not a value color");
+            throw new Exception("Not a value color");
         }
         $out = ""; // Prepare to fill with the results
         for ($i = 1; $i <= 3; $i++) {
@@ -55,7 +55,7 @@ class HexColorChangeExtension extends Twig_Extension
     public function shade($hexcode, $percentage)
     {
         if (!preg_match('/^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i', $hexcode, $parts)) {
-            die("Not a value color");
+            throw new Exception("Not a value color");
         }
         $out = ""; // Prepare to fill with the results
         for ($i = 1; $i <= 3; $i++) {


### PR DESCRIPTION
I've just spent an entire afternoon trying to figure out why a website gave no output at all. I have great error logging set-up but it was reporting nothing. 

For every scenario where die() works (e.g. with no error handling set-up) an exception also works. Furthermore an exception allows error handling to catch the problem and report it leading to a quicker resolution.

Please accept this Pull Request and safe someone some time in the future.